### PR TITLE
Add default home layout

### DIFF
--- a/css/device.css
+++ b/css/device.css
@@ -1,0 +1,13 @@
+#target-info {
+  display: none;
+}
+
+#target-info-placeholder {
+  display: block;
+  padding: 50px 0;
+  text-align: center;
+}
+
+.loading-part {
+  display: none;
+}

--- a/css/home.css
+++ b/css/home.css
@@ -1,0 +1,92 @@
+body {
+  padding-top: 70px;
+}
+
+#home-info {
+  position: relative;
+  display: none;
+  color: #606c71;
+}
+
+#home-info .project-title {
+  padding: 40px 20px;
+}
+
+#home-info .project-title h1 {
+  font-size: 64px;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+#home-info .project-title .lead {
+  color: #245580;
+  font-size: 21px;
+  margin-bottom: 20px;
+}
+
+#home-info .project-overview {
+  position: relative;
+  box-sizing: border-box;
+  font-size: 18px;
+  padding: 40px;
+  padding-bottom: 20px;
+  background-color: #f5f5f5;
+}
+
+#home-info .project-targets {
+  padding: 20px 0;
+}
+
+#home-info .project-targets .target-block a {
+  text-decoration: none;
+  color: #606c71;
+}
+
+#home-info .project-targets .targets-placeholder {
+  margin: 60px 0;
+}
+
+#home-info .project-targets .target-block-content {
+  position: relative;
+  border: 1px solid #ddd;
+  padding: 5px;
+  margin: 10px 0;
+  min-height: 165px;
+}
+
+#home-info .project-targets .target-block-content:hover {
+  border-color: #66afe9;
+  -webkit-box-shadow: 0 0 8px rgba(102,175,233,.6);
+  -moz-box-shadow: 0 0 8px rgba(102,175,233,.6);
+  box-shadow: 0 0 8px rgba(102,175,233,.6);
+  cursor: pointer;
+}
+
+#home-info .project-targets .target-block-content .target-block-header .lead {
+  font-size: 14px;
+}
+
+#home-info .project-targets .target-block-content .target-block-result {
+  position: absolute;
+  width: 100%;
+  bottom: 0;
+  left: 0;
+  margin: 20px 0;
+}
+
+#home-info .project-targets .target-block-content .target-block-result .row {
+  position: relative;
+}
+
+#home-info .project-targets .target-block-content .target-block-result .target-block-result-passed {
+  color: #4a6;
+}
+
+#home-info .project-targets .target-block-content .target-block-result .target-block-result-failed {
+  color: #e44;
+}
+
+#home-info .project-targets .target-block-content .target-block-result .target-block-result-skipped {
+  color: #eb1;
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">
   <link rel="stylesheet" href="css/c3.css">
   <link rel="stylesheet" href="css/chart.css">
+  <link rel="stylesheet" href="css/device.css">
+  <link rel="stylesheet" href="css/home.css">
   <link rel="stylesheet" href="css/infobox.css">
   <link rel="stylesheet" href="css/pagination.css">
   <link rel="stylesheet" href="css/testruns.css">
@@ -21,13 +23,12 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
   <script src="js/third-party/c3/c3.min.js"></script>
   <script src="js/third-party/c3/d3.v3.min.js"></script>
+  <script src="js/constants.js"></script>
+  <script src="js/firebase_init.js"></script>
   <script src="js/chart_settings.js"></script>
   <script src="js/load_jsons.js"></script>
   <script src="js/render_entries.js"></script>
-
-  <style>
-    body { padding-top: 70px; }
-  </style>
+  <script src="js/render_home_stats.js"></script>
 </head>
 <body>
 
@@ -44,8 +45,12 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
-        <li id="show-stm32" class="active"><a href="#">STM32</a></li>
-        <li id="show-rpi2"><a href="#">Raspberry Pi2</a></li>
+        <li id="show-home" class="active"><a id="link-home" href="?view=home">Home</a></li>
+        <li id="show-rpi2"><a id="link-rpi2" href="?view=rpi2">Raspberry Pi2</a></li>
+        <li id="show-stm32"><a id="link-stm32" href="?view=stm32">STM32</a></li>
+      </ul>
+
+      <ul class="nav navbar-nav navbar-right">
         <li><a href="http://github.com/jerryscript-project/jerryscript">View on Github</a></li>
         <li><a href="http://www.jerryscript.net">Powered by <b>JerryScript</b></a></li>
       </ul>
@@ -53,43 +58,67 @@
   </div>
 </nav>
 
-<div class="container infobox">
-  <div class="row">
-    <div class="col-sm-8 col-md-7">
-      <img id="info-image">
-      <div>
-        <p><span class="bold">Test device:</span><a id="info-device"></a></p>
-        <p><span class="bold">Platform:</span><a id="info-platform"></a></p>
-        <p><span class="bold">Repository:</span><a href="https://github.com/jerryscript-project/jerryscript">JerryScript master branch</a></p>
-      </div>
-    </div>
-    <div class="col-sm-4 col-md-5">
-      <small><i class="fa fa-info-circle" aria-hidden="true"></i></small>
-      <small>The binary size information is based on the stripped release build of JerryScript, by cross compiling for the Raspberry Pi 2 target.<br><br>JerryScript tests run once a day using the latest master.</small>
-    </div>
-  </div>
-</div>
-
-<div class="container chart-wrapper">
-  <div class="row">
+<div id="home-info">
+  <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <p>Date range from <input type="text" class="form-control" id="chart-datepicker-from"> to <input type="text" class="form-control" id="chart-datepicker-to"></p>
+        <div class="project-title text-center">
+          <h1>JerryScript</h1>
+          <p class="lead">Automated correctness and performance test results</p>
+        </div>
+        <div class="project-overview">
+          <p>The purpose of the project is to run the official JerryScript test-suite on different platforms. The testing happens once a day (at UTC 17:00) using the latest master.</p>
+          <p>The binary size information is based on the stripped release build of JerryScript, by cross compiling for the Raspberry Pi 2 target.</p>
+          <p>The collected values are visualized on charts that help to observe how JerryScript evolves day by day. If you are interested in a platform, please choose one of the options below.</p>
+        </div>
+        <div class="project-targets" id="home-targets">
+          <p class="text-center targets-placeholder">Loading target information...</p>
+        </div>
       </div>
-    </div>
-    <div class="col-md-6">
-      <div id="binary-chart"></div>
-    </div>
-    <div class="col-md-6">
-      <div id="memory-chart"></div>
     </div>
   </div>
 </div>
 
-<div class="container">
-<div class="pagination top"></div>
-<div id="loading"><p>Loading...</p></div>
-<div id="testruns"></div>
+<div id="target-info">
+
+  <div class="container infobox">
+    <div class="row">
+      <div class="col-sm-8 col-md-7">
+        <img id="info-image">
+        <div>
+          <p><span class="bold">Test device:</span><a id="info-device"></a></p>
+          <p><span class="bold">Platform:</span><a id="info-platform"></a></p>
+          <p><span class="bold">Repository:</span><a href="https://github.com/jerryscript-project/jerryscript">JerryScript master branch</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="target-info-placeholder">
+    <p>Loading the device information...</p>
+  </div>
+
+  <div class="container chart-wrapper loading-part">
+    <div class="row">
+      <div class="row">
+        <div class="col-md-12">
+          <p>Date range from <input type="text" class="form-control" id="chart-datepicker-from"> to <input type="text" class="form-control" id="chart-datepicker-to">
+          </p>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div id="binary-chart"></div>
+      </div>
+      <div class="col-md-6">
+        <div id="memory-chart"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container loading-part">
+    <div class="pagination top"></div>
+    <div id="testruns"></div>
+  </div>
 </div>
 
 <script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>

--- a/js/chart_settings.js
+++ b/js/chart_settings.js
@@ -1,4 +1,4 @@
-var dataset = [];
+var charts = [];
 
 function init_datepickers(first_date, last_date) {
   var picker_options = {
@@ -112,6 +112,8 @@ function generate_chart(data, type, y_axis_min) {
       }
     }
   });
+
+  charts.push(chart);
 }
 
 function iso_date(date) {
@@ -119,22 +121,14 @@ function iso_date(date) {
 }
 
 function fetch_chart_data(device) {
-  generate_chart([], 'binary', 0);
-  generate_chart([], 'memory', 0);
-
-  dataset = [];
-
   if (!firebase.apps.length) {
     return;
   }
 
-  var last_element = "";
-  var first_element = "";
-
   g_db_ref.child(g_db_keys[g_db_keys.length - 1]).once('value').then(function(snapshot) {
     first_element = snapshot.val();
     g_db_ref.child(g_db_keys[0]).once('value').then(function(snapshot) {
-      last_element = snapshot.val();
+      var last_element = snapshot.val();
 
       init_datepickers(iso_date(first_element.date), iso_date(last_element.date));
 
@@ -206,6 +200,9 @@ function update_chart(from, to) {
 
     generate_chart(slice, 'binary', (min_bin_size / 2).toFixed());
     generate_chart(slice, 'memory', (min_avg_memory / 2).toFixed());
+
+
+    render_done('chart');
   });
 }
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,10 @@
+const views = [
+  'home',
+  'stm32',
+  'rpi2'
+];
+
+const devices = {
+  rpi2: 'Raspberry Pi 2',
+  stm32: 'STM32F4-Discovery'
+};

--- a/js/firebase_init.js
+++ b/js/firebase_init.js
@@ -1,0 +1,16 @@
+var firebase = null;
+
+$('document').ready(function() {
+  var config = {
+    apiKey: "AIzaSyDMgyPr0V49Rdf5ODAU9nLY02ZGEUNoxiM",
+    authDomain: "remote-testrunner.firebaseapp.com",
+    databaseURL: "https://remote-testrunner.firebaseio.com",
+    projectId: "remote-testrunner",
+    storageBucket: "remote-testrunner.appspot.com",
+    messagingSenderId: "183582255751"
+  };
+
+  if (!firebase.apps.length) {
+    firebase.initializeApp(config);
+  }
+});

--- a/js/load_jsons.js
+++ b/js/load_jsons.js
@@ -1,19 +1,49 @@
+var rendered_sections = [];
 var g_page_step = 10;
 var g_db_keys = [];
 var g_db_ref = "";
 
 $(document).ready(function() {
-    // $.ajaxSetup({ cache: false });
-    change_device("stm32");
+  var view = get_parameter_by_name('view');
+
+  // Set home as a default view.
+  if (!(views.includes(view))) {
+    view = 'home';
+  }
+
+  change_view(view);
 });
 
-function change_device(device) {
+function change_view(target) {
+  if (target === 'home') {
+    $('#home-info').show();
+    $('#target-info').hide();
+  } else {
+    $('#home-info').hide();
+    $('#target-info').show();
+
+    $('#css-dynamic').attr('href', 'css/device_' + target + '.css');
+
+    clear();
+    set_info(target);
+    fetch_keys(target);
+  }
+
   $('#navbar li').removeClass('active');
-  $('#show-' + device).addClass('active');
-  $('#css-dynamic').attr('href', 'css/device_' + device + '.css');
-  clear();
-  set_info(device);
-  fetch_keys(device);
+  $('#show-' + target).addClass('active');
+}
+
+function render_done(section) {
+  rendered_sections.push(section);
+
+  if (rendered_sections.length === 2) {
+    $('#target-info-placeholder').hide();
+    $('.loading-part').show();
+
+    charts.forEach(function(chart) {
+      chart.flush();
+    });
+  }
 }
 
 function clear() {
@@ -46,19 +76,6 @@ function set_info(device) {
 }
 
 function fetch_keys(device) {
-  var config = {
-    apiKey: "AIzaSyDMgyPr0V49Rdf5ODAU9nLY02ZGEUNoxiM",
-    authDomain: "remote-testrunner.firebaseapp.com",
-    databaseURL: "https://remote-testrunner.firebaseio.com",
-    projectId: "remote-testrunner",
-    storageBucket: "remote-testrunner.appspot.com",
-    messagingSenderId: "183582255751"
-  };
-
-  if (!firebase.apps.length) {
-    firebase.initializeApp(config);
-  }
-
   g_db_keys = []
   g_db_ref = firebase.database().ref('jerryscript/'+ device);
 
@@ -73,4 +90,9 @@ function fetch_keys(device) {
     }
     fetch_chart_data(device);
   });
+}
+
+function get_parameter_by_name(name) {
+  var match = RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search);
+  return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
 }

--- a/js/render_entries.js
+++ b/js/render_entries.js
@@ -1,9 +1,5 @@
 var c_one_day_ms = 1000 * 60 * 60 * 24;
 
-function hide_loading() {
-  $("#loading").hide();
-}
-
 function render_testrun(uid, testrun, earlier_testrun) {
   var passed = 0;
   var skipped = 0;
@@ -330,7 +326,7 @@ function render_testruns(idx, idx_end) {
       }(testrun_ref));
     }
 
-    hide_loading();
+    render_done('entries');
   });
 }
 

--- a/js/render_home_stats.js
+++ b/js/render_home_stats.js
@@ -1,0 +1,106 @@
+var data = [];
+
+$(document).ready(function() {
+  fetch_last_entries();
+});
+
+function fetch_last_entries() {
+  if (firebase.apps.length) {
+    data = [];
+
+    for (const i in devices) {
+      if (devices.hasOwnProperty(i)) {
+        firebase.database().ref('jerryscript/' + i).limitToLast(1).on('child_added', function(childSnapshot) {
+          var snapshot = childSnapshot.val();
+
+          data.push({
+            id: i,
+            name: devices[i],
+            date: snapshot.date,
+            stats: fetch_stats(snapshot.tests)
+          });
+
+          if (data.length === Object.keys(devices).length) {
+            render_project_targets();
+          }
+        });
+      }
+    }
+  }
+}
+
+function fetch_stats(tests) {
+  var stats = {
+    pass: 0,
+    skip: 0,
+    fail: 0
+  };
+
+  for (const i in tests) {
+    if (tests.hasOwnProperty(i)) {
+      const element = tests[i];
+
+      if (element.result === 'pass') {
+        stats.pass++;
+      } else if (element.result === 'skip') {
+        stats.skip++;
+      } else if (element.result === 'fail') {
+        stats.fail++;
+      }
+    }
+  }
+
+  return stats;
+}
+
+function render_target_block_content(target) {
+  var raw_html = '<a href="?view=' + target.id + '">';
+  raw_html += '<div class="target-block-content" id="' + target.id + '-home-result">';
+  raw_html += '<div class="target-block-header text-center">';
+  raw_html += '<h3>' + target.name + '</h3>';
+  raw_html += '<p class="lead">Last measured <b>' + target.date.substr(0, 10) + '</b></p>';
+  raw_html += '</div>';
+  raw_html += '<div class="target-block-result">';
+  raw_html += '<div class="row">';
+  raw_html += '<div class="col-xs-4 col-sm-4 col-md-4 col-lg-4 text-center target-block-result-passed" title="Passed">';
+  raw_html += '<i class="fa fa-check fa-fw" aria-hidden="true"></i>';
+  raw_html += '<span class="result-passed-number">' + target.stats.pass + '</span>';
+  raw_html += '</div>';
+  raw_html += '<div class="col-xs-4 col-sm-4 col-md-4 col-lg-4 text-center target-block-result-failed" title="Failed">';
+  raw_html += '<i class="fa fa-times fa-fw" aria-hidden="true"></i>';
+  raw_html += '<span class="result-failed-number">' + target.stats.fail + '</span>';
+  raw_html += '</div>';
+  raw_html += '<div class="col-xs-4 col-sm-4 col-md-4 col-lg-4 text-center target-block-result-skipped" title="Skipped">';
+  raw_html += '<i class="fa fa-step-forward fa-fw" aria-hidden="true"></i>';
+  raw_html += '<span class="result-skipped-number">' + target.stats.skip + '</span>';
+  raw_html += '</div>';
+  raw_html += '</div>';
+  raw_html += '</div>';
+  raw_html += '</div>';
+  raw_html += '</a>';
+
+  return raw_html;
+}
+
+function render_project_target_col() {
+  var raw_html = '';
+
+  for (const i in data) {
+    if (data.hasOwnProperty(i)) {
+      raw_html += '<div class="col-sm-6 col-md-6 col-lg-6 target-block">';
+      raw_html += render_target_block_content(data[i]);
+      raw_html += '</div>';
+    }
+  }
+
+  return raw_html;
+}
+
+function render_project_targets() {
+
+  var raw_html = '<div class="row">';
+  raw_html += render_project_target_col();
+  raw_html += '</div>';
+
+  $('#home-targets').html(raw_html);
+}


### PR DESCRIPTION
  * Add a default layout as home page in case of unselected device.
  * Load the default home in case of unsupported device.
  * Fetch the last result of the measures in the default view for each target.
  * Change the device selector function.
  * Add a loading layer to the device pages.

Credit: Imre Kiss <kissi.szeged@partner.samsung.com>